### PR TITLE
ps: update callendar and year on footer

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1,7 +1,7 @@
 {
     "navBar": ["ABOUT US", "PROJECTS", "KURUMIM", "SELECTION PROCESS", "OBSAT"],
     "footer": {
-        "copyright": "© 2021  Zenith Aerospace",
+        "copyright": "© 2023  Zenith Aerospace",
         "easterEgg": "MADE WITH TONS OF JAVASCRIPT AND CONFUSION ON DISCORD"
     }
 }

--- a/locales/en/processoSeletivo.json
+++ b/locales/en/processoSeletivo.json
@@ -26,7 +26,6 @@
             "text": [
                 ["13/03", "PARTICIPATION FORMS OPENS"],
                 ["16/03", "PRESENCE AT EESC OPORTUNITIES FAIR"],
-                ["18/03", "AEROESPACIAL PROBE LAUNCH"],
                 ["23/03", "PRESENTATION TALK"],
                 ["28/03", "MEETING WITH ZENITH MEMBERS"],
                 ["08/04", "PARTICIPATION FORMS CLOSES"],

--- a/locales/en/processoSeletivo.json
+++ b/locales/en/processoSeletivo.json
@@ -31,7 +31,7 @@
                 ["08/04", "PARTICIPATION FORMS CLOSES"],
                 ["13/04", "1ª PHASE - GROUP DYNAMIC"],
                 ["15/04", "1ª PHASE RESULTS"],
-                ["18/04", "2ª PHASE STARTS- PROJECT DEVELOPMENT"],
+                ["18/04", "2ª PHASE STARTS - PROJECT DEVELOPMENT"],
                 ["18/05", "2ª PHASE ENDS - PROJECT PRESENTATION"],
                 ["22/05", "DISCLOSURE OF THE APPROVED MEMBERS"]
             ]

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -1,7 +1,7 @@
 {
     "navBar": ["SOBRE NÓS", "PROJETOS", "KURUMIM", "PROCESSO SELETIVO", "OBSAT"],
     "footer": {
-        "copyright": "© 2021  Zenith Aerospace",
+        "copyright": "© 2023  Zenith Aerospace",
         "easterEgg": "FEITO COM MUITO JAVASCRIPT E CONFUSÃO NO DISCORD"
     }
 }

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -1,7 +1,7 @@
 {
     "navBar": ["SOBRE NÓS", "PROJETOS", "KURUMIM", "PROCESSO SELETIVO", "OBSAT"],
     "footer": {
-        "copyright": "© 2021  Zenith Aerospace",
+        "copyright": "© 2023  Zenith Aerospace",
         "easterEgg": "FEITO COM MUITO JAVASCRIPT E CONFUSÃO NO DISCORD"
     }
 }

--- a/locales/pt/processoSeletivo.json
+++ b/locales/pt/processoSeletivo.json
@@ -26,7 +26,6 @@
             "text": [
                 ["13/03", "LANÇAMENTO DO FORMULÁRIO DE INSCRIÇÃO"],
                 ["16/03", "PRESENÇA NA MOSTRA DE OPORTUNIDADES EESC"],
-                ["18/03", "LANÇAMENTO DE SONDA AEROESPACIAL"],
                 ["23/03", "PALESTRA DE APRESENTAÇÃO"],
                 ["28/03", "RODA DE CONVERSA COM OS MEMBROS DO ZENITH"],
                 ["08/04", "ENCERRAMENTO DAS INSCRIÇÕES"],

--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
     {
       "name": "Fulvio Favilla Filho",
       "url": "https://github.com/fulvio-f"
+    },
+    {
+      "name": "Guilherme Lorete Schmidt",
+      "url": "https://github.com/Guilherme-L-Schmidt"
     }
   ],
   "license": "MIT",


### PR DESCRIPTION
Remove o lançamento do calendário de eventos do PS (foi adiado e não possui data definitiva).
Também atualiza o ano presente no footer do site (junto ao copyright), de 2021 para 2023.

